### PR TITLE
Declare support for the Heroku-20 stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -24,6 +24,9 @@ homepage = "https://github.com/projectriff/streaming-http-adapter-buildpack"
 id = "heroku-18"
 
 [[stacks]]
+id = "heroku-20"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"
 
 [[stacks]]
@@ -35,7 +38,7 @@ name    = "riff Streaming HTTP Adapter"
 version = "0.5.4"
 uri     = "https://storage.googleapis.com/download/storage/v1/b/projectriff/o/streaming-http-adapter%2Fstreaming-http-adapter-linux-amd64-0.5.4-20200610023426-2153adc7da97497c.tgz?generation=1591756563479537&alt=media"
 sha256  = "d408dcee6beaf5edb76ce8cae369e7cd2b6f374248961c9cabcddf37ff935a28"
-stacks  = [ "heroku-18", "io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3" ]
+stacks  = [ "heroku-18", "heroku-20", "io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3" ]
 
   [[metadata.dependencies.licenses]]
   type = "Apache-2.0"


### PR DESCRIPTION
Since we've recently released a beta of the Heroku-20 stack:
https://devcenter.heroku.com/changelog-items/1937

And have published the first set of run/build-time images:
https://github.com/heroku/pack-images/pull/133

Closes GUS-W-8270780.

Many thanks :-)